### PR TITLE
[Issue/#64] 이미지 삭제시, 인덱스 초과로 인한 오류 해결

### DIFF
--- a/src/main/java/server/inuappcenter/kr/service/ImageService.java
+++ b/src/main/java/server/inuappcenter/kr/service/ImageService.java
@@ -40,21 +40,23 @@ public class ImageService {
     @Transactional
     public void deleteMultipleImages(Long board_id, List<Long> image_ids) {
         Board foundBoard = boardRepository.findById(board_id).orElseThrow(() -> new CustomNotFoundException("The requested ID was not found."));
+
         List<Long> foundImageIds = new ArrayList<>();
         for (Image image: foundBoard.getImages()) {
             foundImageIds.add(image.getId());
         }
+
         if (!new HashSet<>(foundImageIds).containsAll(image_ids)) {
             throw new CustomNotFoundException("The requested ID was not found.");
         }
 
+        // remove() 함수는 리스트 자체를 변경 -> 역순으로 순회 -> 인덱스 초과x
         int imagesListSize = foundBoard.getImages().size();
-        for (int i = 0; i < imagesListSize; i++) {
-            for (Long imageId : image_ids) {
-                if (Objects.equals(foundBoard.getImages().get(i).getId(), imageId)) {
-                    foundBoard.getImages().remove(i);
-                    imageRepository.deleteById(imageId);
-                }
+        for (int i = imagesListSize -1 ; i >= 0 ; i--) {
+            Image image = foundBoard.getImages().get(i);
+            if(image_ids.contains(image.getId())) {
+                foundBoard.getImages().remove(i);
+                imageRepository.deleteById(image.getId());
             }
         }
     }


### PR DESCRIPTION
## 📋 이슈 번호

close #64 

## 🛠 구현 사항

인덱스 순회를 역순으로 변경하여, IndexOutOfBoundsException 가 발생하지 않도록 로직을 변경하였습니다.

## 📚 기타
