### PR TITLE
[Bug/#66] 사진게시판 이미지 수정 

### DIFF
--- a/src/main/java/server/inuappcenter/kr/data/domain/board/PhotoBoard.java
+++ b/src/main/java/server/inuappcenter/kr/data/domain/board/PhotoBoard.java
@@ -61,7 +61,7 @@ public class PhotoBoard extends Board {
 
     @Override
     public void updateImage(List<Image> images) {
-        this.images = images;
+        this.images.addAll(images);
     }
 
     @Override

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,18 +1,18 @@
 spring:
   redis:
     port: 5379
-    host: na2ru2.me
-    sentinel:
-      username: appcenter-homepage
-      password: appcenter-homepage1!
+    host: localhost
+      #sentinel:
+    # username: appcenter-homepage
+    # password: appcenter-homepage1!
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
     username: dev
-    url: jdbc:mysql://na2ru2.me:6306/appcenter
+    url: jdbc:mysql://localhost:6306/appcenter
     password: test1234
   jpa:
     hibernate:
-      ddl-auto: none
+      ddl-auto: update
     show-sql: true
     open-in-view: false
     properties:


### PR DESCRIPTION
## 📋 이슈 번호

close #66 

## 🛠 구현 사항

- [x] 이미지 수정과 추가를 할 시, board_id가 null 값이 되는 이슈를 해결하였습니다.

- [x] 개발용 application.yml을 로컬로 변경하였습니다.

## 📚 기타
